### PR TITLE
added release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 chrono = "0.4"
 dotenv = "0.15"
+
+[profile.release]
+lto = "fat"
+codegen-units = 1


### PR DESCRIPTION
lto will enable link time optimization across all crates

codegen-units enables the compiler to optimize better across chunks (this sets it so that 1 crate = 1 chunk), by default it tries to split crates into as many chunks as possible to compile them in parallel, while it might speed up compile time, it sure limits the possible optimizations taking place.