### PR TITLE
Dynamic Settings & Much More

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd0210d8c325c245ff06fd95a3b13689a1a276ac8cfa8e8720cb840bfb84b9e"
+checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -378,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc8cd39e3dbf865f7340dce6a2d401d24fd37c6fe6c4f0ee0de8bfca2252d27"
+checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -388,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629316e42fe7c2a0b9a65b47d159ceaa5453ab14e8f0a3c5eedbb8cd55b4a445"
+checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
 
 [[package]]
 name = "futures-intrusive"
@@ -405,15 +405,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e481354db6b5c353246ccf6a728b0c5511d752c08da7260546fc0933869daa11"
+checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89f17b21645bc4ed773c69af9c9a0effd4a3f1a3876eadd453469f8854e7fdd"
+checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -422,21 +422,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "996c6442437b62d21a32cd9906f9c41e7dc1e19a9579843fad948696769305af"
+checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
 
 [[package]]
 name = "futures-task"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabf1872aaab32c886832f2276d2f5399887e2bd613698a02359e4ea83f8de12"
+checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
 
 [[package]]
 name = "futures-util"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d22213122356472061ac0f1ab2cee28d2bac8491410fd68c2af53d1cedb83e"
+checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ The bot requires a postgresql database with a table based on the schema in `sql/
   welcome_channel: <Discord channel id for channel to send user welcome messages in>
   welcome_messages: <Array of welcome messages, "%user%" is substituted for the joined members mention, ["*%user% joined*", ...]>
   owners: <Array of owner user ids, [<user_id>, <user_id>...]>
-  boost_level: <The boost level of the server>
 ```
 
 You need to set the `DATABASE_URL` variable in `.env` to the same value as `sqlx_config` in the config file to allow for compile time checking of database calls.

--- a/sql/ttc-bot.sql
+++ b/sql/ttc-bot.sql
@@ -35,9 +35,16 @@ END$$;
 
 DROP TABLE IF EXISTS ttc_conveyance_state;
 CREATE TABLE ttc_conveyance_state(
-	id SERIAL,
-	current_id INT NOT NULL,
-	PRIMARY KEY(id)
+	current_id INT NOT NULL
 );
 
 INSERT INTO ttc_conveyance_state (current_id) VALUES(0);
+
+DROP TABLE IF EXISTS ttc_config;
+CREATE TABLE ttc_config(
+	support_channel BIGINT NOT NULL,
+	conveyance_channel BIGINT NOT NULL,
+	conveyance_blacklisted_channels BIGINT[] NOT NULL,
+	welcome_channel BIGINT NOT NULL,
+	welcome_messages VARCHAR(100)[] NOT NULL
+);

--- a/src/client/hooks.rs
+++ b/src/client/hooks.rs
@@ -109,6 +109,7 @@ pub async fn after(ctx: &Context, msg: &Message, cmd_name: &str, error: Result<(
 // Not necessarily a hook but it is close enough so here it shall stay
 
 #[help]
+#[lacking_role(hide)]
 #[embed_error_colour(RED)]
 #[embed_success_colour(FOOYOO)]
 async fn help(

--- a/src/client/hooks.rs
+++ b/src/client/hooks.rs
@@ -84,7 +84,7 @@ pub async fn after(ctx: &Context, msg: &Message, cmd_name: &str, error: Result<(
     match error {
         Ok(_) => (),
         Err(why) => {
-            log::error!("Command {} returned with an Err value: {}", cmd_name, why);
+            log::warn!("Command {} returned with an Err value: {}", cmd_name, why);
             match msg
                 .channel_id
                 .send_message(ctx, |m| {

--- a/src/client/hooks.rs
+++ b/src/client/hooks.rs
@@ -44,7 +44,7 @@ pub async fn dispatch_error(ctx: &Context, msg: &Message, error: DispatchError) 
                     m.embed(|e| {
                         e.title("Not enough arguments")
                             .description(format!(
-                                "A minimum of *{}* arguments is required, {} was provided.",
+                                "A minimum of **{}** arguments is required, {} was provided.",
                                 min, given
                             ))
                             .color(Color::RED)

--- a/src/groups/admin.rs
+++ b/src/groups/admin.rs
@@ -10,7 +10,7 @@ use serenity::{
 };
 
 #[group]
-#[prefixes("admin")]
+#[prefix("admin")]
 #[owners_only]
 #[commands(shutdown)]
 struct Admin;

--- a/src/groups/config.rs
+++ b/src/groups/config.rs
@@ -15,7 +15,7 @@ use crate::{
 
 #[group]
 #[owners_only]
-#[prefixes("config")]
+#[prefix("config")]
 #[commands(set, get)]
 struct Config;
 

--- a/src/groups/config.rs
+++ b/src/groups/config.rs
@@ -1,0 +1,172 @@
+use serenity::{
+    client::Context,
+    framework::standard::{
+        macros::{command, group},
+        Args, CommandError, CommandResult,
+    },
+    model::channel::Message,
+    utils::Color,
+};
+
+use crate::{
+    typemap::{config, types::PgPoolType},
+    utils::helper_functions::embed_msg,
+};
+
+#[group]
+#[owners_only]
+#[prefixes("config")]
+#[commands(set, get)]
+struct Config;
+
+#[command]
+#[min_args(2)]
+async fn set(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
+    args.quoted();
+
+    let data = ctx.data.read().await;
+    let pool = data.get::<PgPoolType>().unwrap();
+    // Get the config from the database
+    let mut config = match config::Config::get_from_db(pool).await {
+        Ok(config) => config,
+        Err(why) => {
+            return Err(CommandError::from(format!(
+                "Error reading from the database: {}",
+                why
+            )));
+        }
+    };
+    let property: String = args.single()?;
+
+    // Match the requested config field to predefined fields
+    match &property[..] {
+        "support_channel" => {
+            let value: String = args.single()?;
+            config.support_channel = match value.parse::<i64>() {
+                Ok(value) => value,
+                Err(why) => return Err(CommandError::from(format!("Parsing error: {}", why))),
+            }
+        }
+        "conveyance_channel" => {
+            let value: String = args.single()?;
+            config.conveyance_channel = match value.parse::<i64>() {
+                Ok(value) => value,
+                Err(why) => return Err(CommandError::from(format!("Parsing error: {}", why))),
+            }
+        }
+        "conveyance_blacklisted_channels" => {
+            let mut values: Vec<i64> = Vec::new();
+            for value in args.iter() {
+                let value: String = value?;
+                values.push(match value.parse::<i64>() {
+                    Ok(value) => value,
+                    Err(why) => return Err(CommandError::from(format!("Parsing error: {}", why))),
+                })
+            }
+            config.conveyance_blacklisted_channels = values;
+        }
+        "welcome_channel" => {
+            let value: String = args.single()?;
+            config.welcome_channel = match value.parse::<i64>() {
+                Ok(value) => value,
+                Err(why) => return Err(CommandError::from(format!("Parsing error: {}", why))),
+            }
+        }
+        "welcome_messages" => {
+            let mut values: Vec<String> = Vec::new();
+            for value in args.iter() {
+                let value: String = value?;
+                values.push(value[1..value.len() - 1].to_string());
+            }
+            config.welcome_messages = values;
+        }
+        _ => {
+            embed_msg(
+                ctx,
+                &msg.channel_id,
+                Some("Nothing found"),
+                Some(&format!("No field found for name {}.", property)),
+                Some(Color::RED),
+                None,
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+
+    match config.save_in_db(pool).await {
+        Ok(_) => (),
+        Err(why) => {
+            return Err(CommandError::from(format!(
+                "Error saving config into database: {}",
+                why
+            )))
+        }
+    }
+
+    embed_msg(
+        ctx,
+        &msg.channel_id,
+        Some("Value set successfully"),
+        Some(&format!("Value for `{}` set successfully", property)),
+        Some(Color::PURPLE),
+        None,
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[command]
+#[num_args(1)]
+async fn get(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
+    let data = ctx.data.read().await;
+    let pool = data.get::<PgPoolType>().unwrap();
+
+    // Get the config from the database
+    let config = match config::Config::get_from_db(pool).await {
+        Ok(config) => config,
+        Err(why) => {
+            return Err(CommandError::from(format!(
+                "Error reading from the database: {}",
+                why
+            )));
+        }
+    };
+    let property: String = args.single()?;
+
+    // Match the requested config field to predefined fields
+    let property_value = match &property[..] {
+        "support_channel" => format!("{}", config.support_channel),
+        "conveyance_channel" => format!("{}", config.conveyance_channel),
+        "conveyance_blacklisted_channels" => {
+            format!("{:?}", config.conveyance_blacklisted_channels)
+        }
+        "welcome_channel" => format!("{}", config.welcome_channel),
+        "welcome_messages" => format!("{:?}", config.welcome_messages),
+        _ => {
+            embed_msg(
+                ctx,
+                &msg.channel_id,
+                Some("Nothing found"),
+                Some(&format!("No field found for name {}.", property)),
+                Some(Color::RED),
+                None,
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+
+    embed_msg(
+        ctx,
+        &msg.channel_id,
+        Some(&format!("Value for `{}`", property)),
+        Some(&property_value),
+        Some(Color::PURPLE),
+        None,
+    )
+    .await?;
+
+    Ok(())
+}

--- a/src/groups/moderation.rs
+++ b/src/groups/moderation.rs
@@ -1,20 +1,24 @@
+use crate::utils::helper_functions::embed_msg;
 use serenity::{
     client::Context,
     framework::standard::{
         macros::{command, group},
         Args, CommandError, CommandResult,
     },
-    model::{channel::Message, id::UserId, prelude::User},
+    model::{channel::Message, id::UserId},
+    utils::Color,
 };
 
 #[group]
-#[prefixes("mod")]
+#[prefix("mod")]
+#[allowed_roles("Moderator")]
 #[commands(ban)]
 struct Moderation;
 
 #[command]
 #[min_args(1)]
-async fn ban(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
+#[max_args(2)]
+async fn ban(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
     let user = match match args.parse::<UserId>() {
         Ok(user_id) => user_id,
         Err(why) => return Err(CommandError::from(format!("Invalid user id: {}", why))),
@@ -24,6 +28,35 @@ async fn ban(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
     {
         Ok(user) => user,
         Err(why) => return Err(CommandError::from(format!("Invalid user: {}", why))),
+    };
+
+    if user == msg.author {
+        embed_msg(
+            ctx,
+            &msg.channel_id,
+            Some("That's a bad idea."),
+            Some("You really should not try to ban yourself."),
+            Some(Color::DARK_RED),
+            None,
+        )
+        .await?;
+        return Ok(());
+    }
+
+    let guild_id = match msg.guild_id {
+        Some(guild_id) => guild_id,
+        None => return Err(CommandError::from("No guild id available!")),
+    };
+
+    match args.parse::<String>() {
+        Ok(reason) => match guild_id.ban_with_reason(ctx, user, 2, reason).await {
+            Ok(_) => (),
+            Err(why) => return Err(CommandError::from(format!("Error banning user: {}", why))),
+        },
+        Err(_) => match guild_id.ban(ctx, user, 2).await {
+            Ok(_) => (),
+            Err(why) => return Err(CommandError::from(format!("Error banning user: {}", why))),
+        },
     };
 
     Ok(())

--- a/src/groups/moderation.rs
+++ b/src/groups/moderation.rs
@@ -1,0 +1,30 @@
+use serenity::{
+    client::Context,
+    framework::standard::{
+        macros::{command, group},
+        Args, CommandError, CommandResult,
+    },
+    model::{channel::Message, id::UserId, prelude::User},
+};
+
+#[group]
+#[prefixes("mod")]
+#[commands(ban)]
+struct Moderation;
+
+#[command]
+#[min_args(1)]
+async fn ban(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
+    let user = match match args.parse::<UserId>() {
+        Ok(user_id) => user_id,
+        Err(why) => return Err(CommandError::from(format!("Invalid user id: {}", why))),
+    }
+    .to_user(ctx)
+    .await
+    {
+        Ok(user) => user,
+        Err(why) => return Err(CommandError::from(format!("Invalid user: {}", why))),
+    };
+
+    Ok(())
+}

--- a/src/logging/conveyance.rs
+++ b/src/logging/conveyance.rs
@@ -179,7 +179,7 @@ pub async fn message_delete(ctx: &Context, channel_id: &ChannelId, deleted_messa
 pub async fn message_update(
     ctx: &Context,
     old: Option<Message>,
-    _: Option<Message>,
+    new: Option<Message>,
     event: &MessageUpdateEvent,
 ) {
     // Make sure the edit doesn't happen in a blacklisted channel
@@ -229,8 +229,23 @@ pub async fn message_update(
             message_embed.field("Old", "No old message content available", false);
         }
     }
+
+    // Make sure the event is about the content being edited
     match &event.content {
         Some(content) => {
+            // Check if the new message is available
+            match new {
+                Some(new) => {
+                    let mut content_safe = new.content_safe(ctx).await;
+                    content_safe.truncate(1024);
+                    if content_safe == "" {
+                        content_safe = "None".to_string();
+                    }
+                    message_embed.field("New", content_safe, false);
+                }
+                None => {}
+            }
+
             let mut content_safe =
                 content_safe(ctx, &content, &ContentSafeOptions::default()).await;
             content_safe.truncate(1024);

--- a/src/logging/conveyance.rs
+++ b/src/logging/conveyance.rs
@@ -122,7 +122,12 @@ pub async fn message_delete(ctx: &Context, channel_id: &ChannelId, deleted_messa
     {
         Ok(msg) => msg,
         Err(why) => {
-            log::error!("Error reading message from message cache database: {}", why);
+            match why {
+                sqlx::Error::RowNotFound => {
+                    log::info!("Could not locate deleted message in database");
+                }
+                _ => log::error!("Error reading message from message cache database: {}", why),
+            }
             return;
         }
     };

--- a/src/logging/conveyance.rs
+++ b/src/logging/conveyance.rs
@@ -13,12 +13,7 @@ use serenity::{
     utils::{content_safe, Color, ContentSafeOptions},
 };
 
-use crate::{
-    typemap::types::{
-        ConveyanceBlacklistedChannelsType, PgPoolType, WelcomeChannelType, WelcomeMessagesType,
-    },
-    ConveyanceChannelType,
-};
+use crate::typemap::{config::Config, types::PgPoolType};
 use rand::seq::SliceRandom;
 
 // Types for fetching/writing data from/to SQL database
@@ -49,7 +44,7 @@ pub async fn message(ctx: &Context, msg: &Message) {
 
     let mut id = match sqlx::query_as!(
         CurrentIndex,
-        r#"SELECT current_id FROM ttc_conveyance_state WHERE id = 1"#
+        r#"SELECT current_id FROM ttc_conveyance_state"#
     )
     .fetch_one(pool)
     .await
@@ -89,7 +84,7 @@ pub async fn message(ctx: &Context, msg: &Message) {
     }
 
     match sqlx::query!(
-        r#"UPDATE ttc_conveyance_state SET current_id = $1 WHERE id = 1"#,
+        r#"UPDATE ttc_conveyance_state SET current_id = $1"#,
         id.current_id
     )
     .execute(pool)
@@ -106,8 +101,14 @@ pub async fn message(ctx: &Context, msg: &Message) {
 // Send logging messages when messages are deleted
 pub async fn message_delete(ctx: &Context, channel_id: &ChannelId, deleted_message_id: &MessageId) {
     let data = ctx.data.read().await;
-    let conveyance_channel_id = ChannelId(*data.get::<ConveyanceChannelType>().unwrap());
     let pool = data.get::<PgPoolType>().unwrap();
+    let config = match Config::get_from_db(pool).await {
+        Ok(config) => config,
+        Err(why) => {
+            log::error!("Error getting config from database: {}", why);
+            return;
+        }
+    };
 
     // Get the cached message from the database
     let msg = match sqlx::query_as!(
@@ -150,7 +151,7 @@ pub async fn message_delete(ctx: &Context, channel_id: &ChannelId, deleted_messa
     content.truncate(1024);
     attachments.truncate(1024);
 
-    match conveyance_channel_id
+    match ChannelId(config.conveyance_channel as u64)
         .send_message(ctx, |m| {
             m.embed(|e| {
                 e.title("Message deleted")
@@ -182,17 +183,25 @@ pub async fn message_update(
     new: Option<Message>,
     event: &MessageUpdateEvent,
 ) {
-    // Make sure the edit doesn't happen in a blacklisted channel
-    match is_in_blacklisted_channel(ctx, &event.channel_id).await {
-        Ok(_) => (),
-        Err(_) => return,
-    }
-
-    // Get the conveyance channel id from the data typemap
-    let conveyance_channel_id = {
+    let config = {
         let data = ctx.data.read().await;
-        ChannelId(*data.get::<ConveyanceChannelType>().unwrap())
+        let pool = data.get::<PgPoolType>().unwrap();
+        match Config::get_from_db(pool).await {
+            Ok(config) => config,
+            Err(why) => {
+                log::error!("Error getting config from database: {}", why);
+                return;
+            }
+        }
     };
+
+    // Make sure the channel isn't blacklisted from conveyance
+    if config
+        .conveyance_blacklisted_channels
+        .contains(&(event.channel_id.0 as i64))
+    {
+        return;
+    }
 
     // Create the embed outside the closures to allow for async calls
     let mut message_embed = CreateEmbed::default();
@@ -236,6 +245,8 @@ pub async fn message_update(
             // Check if the new message is available
             match new {
                 Some(new) => {
+                    log::debug!("Edited message content got based on provided `new` argument");
+
                     let mut content_safe = new.content_safe(ctx).await;
                     content_safe.truncate(1024);
                     if content_safe == "" {
@@ -243,23 +254,40 @@ pub async fn message_update(
                     }
                     message_embed.field("New", content_safe, false);
                 }
-                None => {}
-            }
+                // Try to fetch the new message from the api
+                None => match event.channel_id.message(ctx, event.id).await {
+                    Ok(new) => {
+                        log::debug!("Edited message content got based on provided message got from the channel_id");
 
-            let mut content_safe =
-                content_safe(ctx, &content, &ContentSafeOptions::default()).await;
-            content_safe.truncate(1024);
-            if content_safe == "" {
-                content_safe = "None".to_string();
+                        let mut content_safe = new.content_safe(ctx).await;
+                        content_safe.truncate(1024);
+                        if content_safe == "" {
+                            content_safe = "None".to_string();
+                        }
+                        message_embed.field("New", content_safe, false);
+                    }
+                    // Fall back to the event in case all other methods fail
+                    Err(why) => {
+                        log::error!("Error getting message: {}", why);
+                        log::debug!("Edited message content got based on raw event");
+
+                        let mut content_safe =
+                            content_safe(ctx, &content, &ContentSafeOptions::default()).await;
+                        content_safe.truncate(1024);
+                        if content_safe == "" {
+                            content_safe = "None".to_string();
+                        }
+                        message_embed.field("New", content_safe, false);
+                    }
+                },
             }
-            message_embed.field("New", content_safe, false);
         }
         None => {
             return;
         }
     }
 
-    match conveyance_channel_id
+    match ChannelId(config.conveyance_channel as u64)
         .send_message(ctx, |m| m.set_embed(message_embed))
         .await
     {
@@ -272,19 +300,25 @@ pub async fn message_update(
 }
 
 pub async fn guild_member_addition(ctx: &Context, new_member: &Member) {
-    let (conveyance_channel_id, welcome_channel_id, welcome_messages) = {
+    let config = {
         let data = ctx.data.read().await;
-        (
-            ChannelId(*data.get::<ConveyanceChannelType>().unwrap()),
-            ChannelId(*data.get::<WelcomeChannelType>().unwrap()),
-            data.get::<WelcomeMessagesType>().unwrap().clone(),
-        )
+        let pool = data.get::<PgPoolType>().unwrap();
+        match Config::get_from_db(pool).await {
+            Ok(config) => config,
+            Err(why) => {
+                log::error!("Error getting config from database: {}", why);
+                return;
+            }
+        }
     };
 
-    let welcome_message = welcome_messages.choose(&mut rand::thread_rng()).unwrap();
+    let welcome_message = config
+        .welcome_messages
+        .choose(&mut rand::thread_rng())
+        .unwrap();
     let welcome_message = welcome_message.replace("%user%", &new_member.mention().to_string());
 
-    match welcome_channel_id
+    match ChannelId(config.welcome_channel as u64)
         .send_message(ctx, |m| m.content(welcome_message))
         .await
     {
@@ -295,7 +329,7 @@ pub async fn guild_member_addition(ctx: &Context, new_member: &Member) {
         }
     }
 
-    match conveyance_channel_id
+    match ChannelId(config.conveyance_channel as u64)
         .send_message(ctx, |m| {
             m.embed(|e| {
                 e.title("New member joined")
@@ -316,9 +350,16 @@ pub async fn guild_member_addition(ctx: &Context, new_member: &Member) {
 }
 
 pub async fn guild_member_removal(ctx: &Context, user: &User, member: Option<Member>) {
-    let conveyance_channel_id = {
+    let config = {
         let data = ctx.data.read().await;
-        ChannelId(*data.get::<ConveyanceChannelType>().unwrap())
+        let pool = data.get::<PgPoolType>().unwrap();
+        match Config::get_from_db(pool).await {
+            Ok(config) => config,
+            Err(why) => {
+                log::error!("Error getting config from database: {}", why);
+                return;
+            }
+        }
     };
 
     let joined_at = match member {
@@ -329,7 +370,7 @@ pub async fn guild_member_removal(ctx: &Context, user: &User, member: Option<Mem
         None => "Join date not available".to_string(),
     };
 
-    match conveyance_channel_id
+    match ChannelId(config.conveyance_channel as u64)
         .send_message(ctx, |m| {
             m.embed(|e| {
                 e.title("Member left")
@@ -344,17 +385,4 @@ pub async fn guild_member_removal(ctx: &Context, user: &User, member: Option<Mem
         Ok(_) => (),
         Err(why) => log::error!("Error sending message: {}", why),
     }
-}
-
-// Helper for making sure that the message is not in a conveyance blacklisted channel
-async fn is_in_blacklisted_channel(ctx: &Context, channel_id: &ChannelId) -> Result<(), ()> {
-    let data = ctx.data.read().await;
-    let conveyance_blacklisted_channel_ids =
-        data.get::<ConveyanceBlacklistedChannelsType>().unwrap();
-
-    if conveyance_blacklisted_channel_ids.contains(&channel_id.0) {
-        return Err(());
-    }
-
-    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,12 @@
 // -------------------
 
 mod typemap {
+    pub mod config;
     pub mod types;
 }
 mod groups {
     pub mod admin;
+    pub mod config;
     pub mod general;
     pub mod support;
 }
@@ -55,6 +57,13 @@ async fn main() {
                 .short("c")
                 .long("config"),
         )
+        .arg(
+            Arg::with_name("write-db")
+                .takes_value(false)
+                .required(false)
+                .short("w")
+                .long("write"),
+        )
         .get_matches();
 
     // Get environment values from .env for ease of use
@@ -75,8 +84,8 @@ async fn main() {
         .as_sequence()
         .unwrap()
         .iter()
-        .map(|val| val.as_u64().unwrap())
-        .collect::<Vec<u64>>();
+        .map(|val| val.as_i64().unwrap())
+        .collect::<Vec<i64>>();
     let welcome_channel_id = config["welcome_channel"].as_u64().unwrap();
     let welcome_messages = config["welcome_messages"]
         .as_sequence()
@@ -84,7 +93,6 @@ async fn main() {
         .iter()
         .map(|val| val.as_str().unwrap().to_string())
         .collect::<Vec<String>>();
-    let boost_level = config["boost_level"].as_u64().unwrap(); // For selecting default archival period
     let mut owners = HashSet::new();
 
     for owner in config["owners"].as_sequence().unwrap() {
@@ -98,6 +106,18 @@ async fn main() {
         .await
         .unwrap();
 
+    if matches.is_present("write-db") {
+        let config = typemap::config::Config {
+            support_channel: support_channel_id as i64,
+            conveyance_channel: conveyance_channel_id as i64,
+            conveyance_blacklisted_channels: conveyance_blacklisted_channel_ids,
+            welcome_channel: welcome_channel_id as i64,
+            welcome_messages: welcome_messages,
+        };
+
+        config.save_in_db(&pool).await.unwrap();
+    }
+
     // Create the framework of the bot
     let framework = StandardFramework::new()
         .configure(|c| c.prefix("ttc!").owners(owners))
@@ -107,7 +127,8 @@ async fn main() {
         .after(client::hooks::after)
         .group(&groups::general::GENERAL_GROUP)
         .group(&groups::support::SUPPORT_GROUP)
-        .group(&groups::admin::ADMIN_GROUP);
+        .group(&groups::admin::ADMIN_GROUP)
+        .group(&groups::config::CONFIG_GROUP);
 
     // Create the bot client
     let mut client = Client::builder(token)
@@ -125,12 +146,6 @@ async fn main() {
         data.insert::<ThreadNameRegexType>(Regex::new("[^a-zA-Z0-9 ]").unwrap());
         data.insert::<UsersCurrentlyQuestionedType>(Vec::new());
         data.insert::<PgPoolType>(pool);
-        data.insert::<SupportChannelType>(support_channel_id);
-        data.insert::<ConveyanceChannelType>(conveyance_channel_id);
-        data.insert::<ConveyanceBlacklistedChannelsType>(conveyance_blacklisted_channel_ids);
-        data.insert::<WelcomeChannelType>(welcome_channel_id);
-        data.insert::<WelcomeMessagesType>(welcome_messages);
-        data.insert::<BoostLevelType>(boost_level);
     }
     match client.start().await {
         Ok(_) => (),

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod groups {
     pub mod admin;
     pub mod config;
     pub mod general;
+    pub mod moderation;
     pub mod support;
 }
 mod utils {
@@ -128,7 +129,8 @@ async fn main() {
         .group(&groups::general::GENERAL_GROUP)
         .group(&groups::support::SUPPORT_GROUP)
         .group(&groups::admin::ADMIN_GROUP)
-        .group(&groups::config::CONFIG_GROUP);
+        .group(&groups::config::CONFIG_GROUP)
+        .group(&groups::moderation::MODERATION_GROUP);
 
     // Create the bot client
     let mut client = Client::builder(token)
@@ -147,6 +149,7 @@ async fn main() {
         data.insert::<UsersCurrentlyQuestionedType>(Vec::new());
         data.insert::<PgPoolType>(pool);
     }
+
     match client.start().await {
         Ok(_) => (),
         Err(why) => log::error!("An error occurred when starting the client: {}", why),

--- a/src/typemap/config.rs
+++ b/src/typemap/config.rs
@@ -1,0 +1,39 @@
+use sqlx::PgPool;
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub support_channel: i64,
+    pub conveyance_channel: i64,
+    pub conveyance_blacklisted_channels: Vec<i64>,
+    pub welcome_channel: i64,
+    pub welcome_messages: Vec<String>,
+}
+
+impl Config {
+    pub async fn save_in_db(&self, pool: &PgPool) -> Result<(), sqlx::Error> {
+        sqlx::query!(r#"DELETE FROM ttc_config"#)
+            .execute(pool)
+            .await?;
+
+        sqlx::query!(
+            r#"INSERT INTO ttc_config VALUES($1, $2, $3, $4, $5)"#,
+            self.support_channel,
+            self.conveyance_channel,
+            &self.conveyance_blacklisted_channels,
+            self.welcome_channel,
+            &self.welcome_messages,
+        )
+        .execute(pool)
+        .await?;
+
+        log::info!("Settings saved.");
+
+        Ok(())
+    }
+
+    pub async fn get_from_db(pool: &PgPool) -> Result<Self, sqlx::Error> {
+        sqlx::query_as!(Self, r#"SELECT * FROM ttc_config"#)
+            .fetch_one(pool)
+            .await
+    }
+}

--- a/src/typemap/types.rs
+++ b/src/typemap/types.rs
@@ -28,33 +28,3 @@ pub struct PgPoolType;
 impl TypeMapKey for PgPoolType {
     type Value = PgPool;
 }
-
-pub struct SupportChannelType;
-impl TypeMapKey for SupportChannelType {
-    type Value = u64;
-}
-
-pub struct BoostLevelType;
-impl TypeMapKey for BoostLevelType {
-    type Value = u64;
-}
-
-pub struct ConveyanceChannelType;
-impl TypeMapKey for ConveyanceChannelType {
-    type Value = u64;
-}
-
-pub struct WelcomeChannelType;
-impl TypeMapKey for WelcomeChannelType {
-    type Value = u64;
-}
-
-pub struct WelcomeMessagesType;
-impl TypeMapKey for WelcomeMessagesType {
-    type Value = Vec<String>;
-}
-
-pub struct ConveyanceBlacklistedChannelsType;
-impl TypeMapKey for ConveyanceBlacklistedChannelsType {
-    type Value = Vec<u64>;
-}


### PR DESCRIPTION
This PR includes new dynamic settings, which can be initially set from the `config.yaml` file with the `-w` command line argument. A ban command is also implemented now. This also fixes the regression that caused the bot to still think you are making a support ticket.