### PR TITLE
Fix serverinfo fields being to long + Conveyance error

### DIFF
--- a/ttc-bot/src/events/conveyance.rs
+++ b/ttc-bot/src/events/conveyance.rs
@@ -226,7 +226,13 @@ pub async fn message_update(
     .await
     {
         Ok(msg) => match msg.content {
-            Some(content) => content,
+            Some(content) => {
+                if content.len() > 0 {
+                    content
+                } else {
+                    "None".to_string()
+                }
+            }
             None => "Not available.".to_string(),
         },
         Err(why) => {


### PR DESCRIPTION
This has been implemented by creating multiple fields when one hits the
1024 char limit. Since the maximum number of fields is 25 there should
be no further problems.