### PR TITLE
Make it possible to untimeout/unmute members; add is_user_timeouted function

### DIFF
--- a/src/commands/moderation.rs
+++ b/src/commands/moderation.rs
@@ -203,10 +203,10 @@ pub async fn kick(
     Ok(())
 }
 
-/// Timeout a member
+/// Mute a member
 ///
-/// Command to timeout a member
-/// ``timeout [member] [duration]``
+/// Command to mute a member
+/// ``mute [member] [duration]``
 ///
 /// ``duration`` is a human-readable string like \
 /// ``1h``
@@ -217,10 +217,10 @@ pub async fn kick(
     required_permissions = "MODERATE_MEMBERS",
     guild_only
 )]
-pub async fn timeout(
+pub async fn mute(
     ctx: Context<'_>,
-    #[description = "The member to timeout"] mut member: Member,
-    #[description = "Time to timeout user"]
+    #[description = "The member to mute"] mut member: Member,
+    #[description = "Time to mute user"]
     #[rename = "duration"]
     duration_str: String,
 ) -> Result<(), Error> {

--- a/src/commands/moderation.rs
+++ b/src/commands/moderation.rs
@@ -1,6 +1,9 @@
 use crate::{
     traits::{context_ext::ContextExt, readable::Readable},
-    utils::bee_utils::{BeeifiedUser, BeezoneChannel},
+    utils::{
+        bee_utils::{BeeifiedUser, BeezoneChannel},
+        helper_functions::is_user_timed_out,
+    },
     Context, Error,
 };
 use chrono::{Duration, Utc};

--- a/src/commands/moderation.rs
+++ b/src/commands/moderation.rs
@@ -267,6 +267,48 @@ pub async fn timeout(
     Ok(())
 }
 
+/// Unmute a member
+///
+/// Command to unmute a member
+/// ``unmute [member]``
+#[poise::command(
+    slash_command,
+    prefix_command,
+    category = "Moderation",
+    required_permissions = "MODERATE_MEMBERS",
+    guild_only
+)]
+pub async fn unmute(
+    ctx: Context<'_>,
+    #[description = "The member to unmute"] mut member: Member,
+) -> Result<(), Error> {
+    // member == author check not needed since you can't type when timed_out
+    if !is_user_timed_out(&member) {
+        ctx.send_simple(
+            true,
+            "User isn't muted",
+            Some(&format!(
+                "The User {} isn't currently muted",
+                member.user.tag()
+            )),
+            ctx.data().colors.input_error().await,
+        )
+        .await?;
+        return Ok(());
+    }
+    member.enable_communication(ctx.discord()).await?;
+
+    ctx.send_simple(
+        false,
+        "User unmuted",
+        Some(&format!("User {} got unmuted", member.user.tag(),)),
+        ctx.data().colors.mod_success().await,
+    )
+    .await?;
+
+    Ok(())
+}
+
 /// Purge messages
 ///
 /// Delete a certain amount of messages (max 100)

--- a/src/events/conveyance.rs
+++ b/src/events/conveyance.rs
@@ -1,4 +1,7 @@
-use crate::{traits::readable::Readable, types::data::Data, unwrap_or_return};
+use crate::{
+    traits::readable::Readable, types::data::Data, unwrap_or_return,
+    utils::helper_functions::is_user_timed_out,
+};
 use chrono::{DateTime, Utc};
 use poise::serenity_prelude::*;
 
@@ -448,17 +451,7 @@ pub async fn guild_member_update(ctx: &Context, old: &Option<Member>, new: &Memb
                 Some(nick) => nick,
                 None => "None".to_string(),
             };
-            let old_timeouted = match old.communication_disabled_until {
-                Some(comm_disabled) => {
-                    if comm_disabled.unix_timestamp() < Timestamp::now().unix_timestamp() {
-                        false
-                    } else {
-                        true
-                    }
-                }
-                None => false,
-            };
-
+            let old_timeouted = is_user_timed_out(&old);
             (old_nickname, old.roles.clone(), Some(old_timeouted))
         }
         None => ("N/A".to_string(), Vec::new(), None),
@@ -469,17 +462,7 @@ pub async fn guild_member_update(ctx: &Context, old: &Option<Member>, new: &Memb
         None => "None".to_string(),
     };
     let new_roles = new.roles.clone();
-    let new_timeouted = match new.communication_disabled_until {
-        Some(comm_disabled) => {
-            if comm_disabled.unix_timestamp() < Timestamp::now().unix_timestamp() {
-                false
-            } else {
-                true
-            }
-        }
-        None => false,
-    };
-
+    let new_timeouted = is_user_timed_out(&new);
     // Make sure it is only the values displayed that have changed
     if !(old_nickname != new_nickname
         || old_roles != new_roles

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,6 +322,7 @@ async fn main() {
                 // Moderation commands
                 commands::moderation::purge(),
                 commands::moderation::timeout(),
+                commands::moderation::unmute(),
                 commands::moderation::kick(),
                 commands::moderation::ban(),
                 commands::moderation::pardon(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -321,7 +321,7 @@ async fn main() {
                 commands::localisation::translate_to_en(),
                 // Moderation commands
                 commands::moderation::purge(),
-                commands::moderation::timeout(),
+                commands::moderation::mute(),
                 commands::moderation::unmute(),
                 commands::moderation::kick(),
                 commands::moderation::ban(),

--- a/src/utils/helper_functions.rs
+++ b/src/utils/helper_functions.rs
@@ -1,4 +1,6 @@
-use poise::serenity_prelude::{ChannelId, Color, Context, CreateEmbed, Message, Webhook};
+use poise::serenity_prelude::{
+    ChannelId, Color, Context, CreateEmbed, Member, Message, Timestamp, Webhook,
+};
 
 use crate::{types::data::Data, Error};
 use std::time::Duration;
@@ -104,4 +106,17 @@ pub async fn get_webhook(
             webhook
         }
     })
+}
+
+pub fn is_user_timed_out(member: &Member) -> bool {
+    return match member.communication_disabled_until {
+        Some(comm_disabled) => {
+            if comm_disabled.unix_timestamp() < Timestamp::now().unix_timestamp() {
+                false
+            } else {
+                true
+            }
+        }
+        None => false,
+    };
 }


### PR DESCRIPTION
``is_user_timeouted`` removes some boilerplate code.
Setting a duration of ``0`` in ``timeout`` unmutes a user; there is also ``unmute`` as alternative