### PR TITLE
Add translation via contextmenu and check for bee

### DIFF
--- a/src/commands/localisation.rs
+++ b/src/commands/localisation.rs
@@ -175,8 +175,23 @@ pub async fn translate_to_en(
     ctx: Context<'_>,
     #[description = "Message to translate"] msg: Message,
 ) -> Result<(), Error> {
-    // Get the language code and the text to translate
+    {
+        let beeified_users = ctx.data().beeified_users.read().await;
+        let beezone_channels = ctx.data().beezone_channels.read().await;
 
+        if beeified_users.contains_key(&ctx.author().id)
+            || beezone_channels.contains_key(&ctx.channel_id())
+        {
+            ctx.send_simple(
+                false,
+                "You are a bee!",
+                Some("Bees can't translate, bees can only... bee."),
+                ctx.data().colors.bee_translate_block().await,
+            )
+            .await?;
+            return Ok(());
+        }
+    }
     ctx.defer().await?;
 
     let (source_lang, translated_text) = translate_text("en".to_string(), &msg.content).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,6 +318,7 @@ async fn main() {
                 commands::general::help(),
                 // Localisation commands
                 commands::localisation::translate(),
+                commands::localisation::translate_to_en(),
                 // Moderation commands
                 commands::moderation::purge(),
                 commands::moderation::timeout(),


### PR DESCRIPTION
This PR (finally) adds the contextmenu option to translate and also adds the same check for beeified users that the normal translation command has too