### PR TITLE
fix(localisation): always convert to full language name

### DIFF
--- a/src/commands/localisation.rs
+++ b/src/commands/localisation.rs
@@ -184,7 +184,7 @@ pub async fn translate(
             .description(format!(
                 "{} -> {}",
                 langcode_to_lang(source_lang.as_str()),
-                lang
+                langcode_to_lang(&lang)
             ))
             .field("Original Message", &text_to_translate, false)
             .field("Translated Message", &translated_text, false)


### PR DESCRIPTION
when using the translate command you can also put in the language code instead of using the full name which would result in the short code being displayed. This commit fixes that