### PR TITLE
improvement(logging): add timestamp to multiple events

### DIFF
--- a/src/events/conveyance.rs
+++ b/src/events/conveyance.rs
@@ -353,6 +353,7 @@ pub async fn guild_member_addition(ctx: &Context, new_member: &Member, data: &Da
                                 &new_member.user.created_at().readable(),
                                 false,
                             )
+                            .timestamp(Utc::now())
                     })
                 })
                 .await,
@@ -390,6 +391,7 @@ pub async fn guild_member_removal(
                             .field("User", user.tag(), true)
                             .field("UserID", user.id, true)
                             .field("Joined at", joined_at.clone(), false)
+                            .timestamp(Utc::now())
                     })
                 })
                 .await,
@@ -413,6 +415,7 @@ pub async fn guild_ban_addition(ctx: &Context, banned_user: &User, data: &Data) 
                             .field("User", banned_user.tag(), true)
                             .field("UserID", banned_user.id, true)
                             .color(color)
+                            .timestamp(Utc::now())
                     })
                 })
                 .await,
@@ -436,6 +439,7 @@ pub async fn guild_ban_removal(ctx: &Context, unbanned_user: &User, data: &Data)
                             .field("User", unbanned_user.tag(), true)
                             .field("UserID", unbanned_user.id, true)
                             .color(color)
+                            .timestamp(Utc::now())
                     })
                 })
                 .await,
@@ -523,6 +527,7 @@ pub async fn guild_member_update(ctx: &Context, old: &Option<Member>, new: &Memb
                             .field("Old roles", &old_roles_string, false)
                             .field("New roles", &new_roles_string, false)
                             .color(color)
+                            .timestamp(Utc::now())
                     })
                 })
                 .await,


### PR DESCRIPTION
this is done to accurately see when something occurred (even with localized time). It affects the following events: guild_member_addition, guild_member_removal guild_ban_addition, guild_ban_removal and guild_member_update