### PR TITLE
build: strip release builds by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ magick_rust = "0.16.0"
 [profile.release]
 lto = "fat"
 codegen-units = 1
+strip = true


### PR DESCRIPTION
this is done since currently all debugging is done in debug builds and release is only used for deployment