### PR TITLE
fix: use serenity fork to support decoding new message components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1895,8 +1895,7 @@ dependencies = [
 [[package]]
 name = "serenity"
 version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d007dc45584ecc47e791f2a9a7cf17bf98ac386728106f111159c846d624be3f"
+source = "git+https://github.com/serenity-rs/serenity.git?rev=f103692#f1036922ffa5caacf6a2dcc2c678962c867fc79c"
 dependencies = [
  "async-trait",
  "async-tungstenite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ strsim = "0.10.0"
 ril = { version = "0.9.0", features = ["all"] }
 urlencoding = "2.1.2"
 
+[patch.crates-io]
+serenity = { git = 'https://github.com/serenity-rs/serenity.git', rev = 'f103692' }
+
 [profile.release]
 lto = "fat"
 codegen-units = 1


### PR DESCRIPTION
this commit changes the serenity dependency to use a fork that has a backported commit that allows decoding more message components. This is done to prevent failure when encountering new component types (like a RoleSelect) until a new serenity version that includes the official is released.

Please note that the CI could fail due to the new submodule