### PR TITLE
fix: show right member status in userinfo

### DIFF
--- a/src/utils/userinfo.rs
+++ b/src/utils/userinfo.rs
@@ -89,14 +89,14 @@ pub async fn userinfo_fn<'a>(
         Some(guild) => {
             let member = guild.member(ctx, user.id).await;
             let status = if member.is_ok() {
-                "Banned".to_string()
+                "Member".to_string()
             } else if guild
                 .bans(ctx)
                 .await?
                 .iter()
                 .any(|ban| ban.user.id.0 == user.id.0)
             {
-                "Member".to_string()
+                "Banned".to_string()
             } else {
                 "Not a member".to_string()
             };


### PR DESCRIPTION
commit 0b3394b0252f17074c24a4a6ed5e88dbc3f8e645 had a bug that results in showing a wrong status when a user is banned/a member. This commit fixes the code paths of the let if blocks